### PR TITLE
Don't reverse rem.children

### DIFF
--- a/util.js
+++ b/util.js
@@ -22,10 +22,9 @@ export async function getRem(options = {}) {
   }
 }
 
-export async function getChildren(rem, visibleOnly = False) {
+export async function getChildren(rem, visibleOnly = false) {
   const children = visibleOnly ? rem.visibleRemOnDocument : rem.children;
   // TODO: Children have the correct order, visibleRemOnDocument don't
-  children.reverse();
   return Promise.all(children.map((remId) => RemNoteAPI.v0.get(remId)));
 }
 


### PR DESCRIPTION
The order of child rems in rem.children is correct. Possibly this was fixed in the RemNote API